### PR TITLE
Fixed OS dependency with __doc__ generation

### DIFF
--- a/tbgrep/__init__.py
+++ b/tbgrep/__init__.py
@@ -16,10 +16,12 @@
 #
 # Copyright (C) 2011 Luke Macken <lmacken@redhat.com>
 
+import os
+
 from collections import defaultdict
 from operator import itemgetter
 
-_file = open('/'.join(__file__.split('/')[:-1]) + '/README.rst')
+_file = open(os.path.join(os.path.dirname(__file__), "README.rst"))
 __doc__ = _file.read()
 _file.close()
 


### PR DESCRIPTION
tbgep is generally cross-platform, except that tbgrep/**init**.py uses hard-coded *nix file separators to build the path to the README.rst file. Therefore, tbgrep is not working on Windows. This micro patch re-implements path manipulations in a cross-platform way - using os.path.
